### PR TITLE
Store DDC at 32*REGBYTES

### DIFF
--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -199,7 +199,7 @@ trap_vector:
   csc ct6,31*REGBYTES(csp)
   csc ct0, 2*REGBYTES(csp)         # sp
   cspecialr ct0, ddc
-  csc ct0,33*REGBYTES(csp)
+  csc ct0,32*REGBYTES(csp)
   cspecialr ct0, mtdc
   cspecialw ddc, ct0
 
@@ -276,7 +276,7 @@ restore_mscratch:
 restore_regs:
   # Restore all of the registers.
 #if __has_feature(capabilities)
-  clc ct0,33*REGBYTES(csp)
+  clc ct0,32*REGBYTES(csp)
   cspecialw ddc, ct0
   clc cra, 1*REGBYTES(csp)
   clc cgp, 3*REGBYTES(csp)


### PR DESCRIPTION
The old offset of 33*REGBYTES is the start of HLS(), so we were clobbering
the first member of HLS() for every context switch. Change the 33 to 32
since that is unused and matches the INTEGER_CONTEXT_SIZE macro.

Before:
```
bbl loader
Setting up PMP to permit access to all of memory
boot_other_hart: 0 -- HLS()=0x000000008000df80, HLS()->ipi=0x0000000002000000
protect_memory()
Using PMP to protect self: 0=0x0000000020000000, 1=0x0000000020005800, 2=0xffffffffffffffff, 3=0x0000000000000000, cfg=00000000001f0800
mcall_trap: 16 -- HLS()=0x000000008000df80, HLS()->ipi=0x0000000000000000
---<<BOOT>>---
KDB: debugger backends: ddb
KDB: current backend: ddb
Physical memory chunk(s):
```

After:
```
bbl loader
Setting up PMP to permit access to all of memory
boot_other_hart: 0 -- HLS()=0x000000008000df80, HLS()->ipi=0x0000000002000000
protect_memory()
Using PMP to protect self: 0=0x0000000020000000, 1=0x0000000020005800, 2=0xffffffffffffffff, 3=0x0000000000000000, cfg=00000000001f0800
mcall_trap: 16 -- HLS()=0x000000008000df80, HLS()->ipi=0x0000000002000000
---<<BOOT>>---
KDB: debugger backends: ddb
KDB: current backend: ddb
Physical memory chunk(s):
```